### PR TITLE
feat: log ChatGPT request events to database

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,38 @@ Cette extension Firefox estime l’empreinte carbone de vos requêtes ChatGPT.
 Elle intercepte les appels réseau du site `chatgpt.com` ainsi que de l’API OpenAI
 et calcule énergie et émissions à partir de facteurs configurables (Options).
 
+### Tester l’extension localement
+
+1. Installez les dépendances (utile si vous souhaitez démarrer le serveur de
+   journalisation ou modifier les sources) :
+
+   ```bash
+   npm install
+   ```
+
+2. Ouvrez Firefox et rendez-vous sur `about:debugging#/runtime/this-firefox`.
+3. Cliquez sur **Charger un module complémentaire temporaire…** et sélectionnez
+   le fichier `manifest.json` à la racine du dépôt. L’extension est alors chargée
+   en mémoire pour cette session.
+4. Épinglez l’icône de l’extension si nécessaire puis ouvrez un onglet sur
+   `https://chatgpt.com/`. Rechargez la page pour que le script d’arrière-plan
+   capte les requêtes réseau.
+5. Ouvrez la popup de l’extension ou le panneau latéral ChatGPT. À chaque
+   requête envoyée à ChatGPT, l’estimation devrait se mettre à jour. Les valeurs
+   restent figées tant qu’aucune réponse n’est envoyée par le site.
+
+Astuce : pour dépanner, ouvrez `about:debugging`, repérez l’extension puis
+cliquez sur **Inspecter**. Vous pourrez consulter la console du service worker
+(`background.js`) et vérifier que les messages d’estimation sont bien émis.
+
 ### Correctifs récents
 
 - Ajout de l’autorisation `tabs` et meilleure détection de l’onglet source pour
   que les estimations s’affichent correctement dans le panneau et la popup.
 - Possibilité d’envoyer chaque estimation vers une API (POST JSON) afin de
   persister les données dans une base distante.
+- Journalisation détaillée des requêtes (début, en-têtes, erreurs, estimation)
+  envoyée vers l’API configurée pour faciliter le dépannage.
 
 ## Journalisation vers PostgreSQL
 
@@ -45,8 +71,14 @@ Au premier lancement, la table `chatgpt_carbon_events` est créée. Chaque appel
 
 Dans la page d’options de l’extension, activez la section « Journalisation » et
 indiquez l’URL complète du point d’entrée (par exemple
-`http://localhost:4000/estimations`). À chaque requête ChatGPT, l’estimation sera
-envoyée à cette adresse.
+`http://localhost:4000/estimations`). À chaque interaction, l’extension émettra
+des événements structurés (`request:start`, `request:headers`, `request:error`,
+`estimation`, etc.) envoyés à cette adresse.
+
+Chaque événement contient un horodatage ISO 8601 (`timestamp`), le type
+(`type`) ainsi que les métriques disponibles au moment du déclenchement. Les
+événements d’estimation incluent toujours les champs énergétiques et carbone
+(`computeWh`, `totalWh`, `kgCO2`, …).
 
 ### Endpoints disponibles
 


### PR DESCRIPTION
## Summary
- broaden the chatgpt.com request filter to include the new /backend-api/f/conversation path
- document the reason for the relaxed match so estimations update again when requests fire
- add centralized logging hooks for the whole request lifecycle and push events to the configured API endpoint
- extend the optional Node/PostgreSQL sink to accept generic events and retain raw payloads for debugging

## Testing
- not run (extension and server changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd5f2afcb0832c98d0606b97a53509