### PR TITLE
Fix requestId column type for Postgres

### DIFF
--- a/server/src/entities/log-event.entity.ts
+++ b/server/src/entities/log-event.entity.ts
@@ -18,7 +18,7 @@ export class LogEvent {
   @Index()
   type!: string;
 
-  @Column({ nullable: true, length: 120 })
+  @Column({ type: 'varchar', length: 120, nullable: true })
   requestId!: string | null;
 
   @Column({ type: 'jsonb' })


### PR DESCRIPTION
## Summary
- explicitly set the requestId column type to varchar so TypeORM does not infer an unsupported Object type

## Testing
- npm run build *(fails: missing NestJS dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7751c560832cabacd553fdf1fe22