### PR TITLE
Add consumption history tracking and dashboard

### DIFF
--- a/front/popup/popup.html
+++ b/front/popup/popup.html
@@ -421,6 +421,169 @@
       font-size: 13px;
     }
 
+    .tabs {
+      display: flex;
+      gap: 8px;
+      align-items: stretch;
+      border-bottom: 1px solid var(--color-border);
+      padding-bottom: 6px;
+      margin-bottom: 8px;
+    }
+
+    .tab-button {
+      flex: 1;
+      border-radius: 10px;
+      padding: 8px 12px;
+      border: 1px solid transparent;
+      background: transparent;
+      color: var(--color-muted);
+      font-weight: 600;
+    }
+
+    .tab-button.active {
+      border-color: var(--color-field-focus-border);
+      background: var(--color-field-bg);
+      color: var(--color-text);
+      box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.15);
+    }
+
+    .tab-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .summary-card {
+      border-radius: 12px;
+      border: 1px solid var(--color-border);
+      background: var(--color-field-bg);
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .summary-header {
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .summary-title {
+      font-weight: 600;
+      font-size: 13px;
+    }
+
+    .summary-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .summary-select {
+      border-radius: 8px;
+      border: 1px solid var(--color-field-border);
+      background: var(--color-surface);
+      color: inherit;
+      padding: 6px 8px;
+      font: inherit;
+    }
+
+    .summary-custom-range {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .summary-custom-range input {
+      border-radius: 8px;
+      border: 1px solid var(--color-field-border);
+      background: var(--color-surface);
+      color: inherit;
+      padding: 4px 6px;
+      font: inherit;
+    }
+
+    .summary-metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 10px;
+    }
+
+    .summary-metric {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .summary-metric strong {
+      font-size: 15px;
+    }
+
+    .history-filters {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: flex-end;
+    }
+
+    .history-filters .field {
+      min-width: 120px;
+    }
+
+    .history-filters input {
+      font-size: 12px;
+      padding: 6px 8px;
+    }
+
+    .history-table-wrapper {
+      border-radius: 12px;
+      border: 1px solid var(--color-border);
+      background: var(--color-field-bg);
+      overflow: hidden;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+
+    thead {
+      background: rgba(99, 102, 241, 0.08);
+    }
+
+    th, td {
+      padding: 8px 10px;
+      text-align: left;
+      border-bottom: 1px solid var(--color-border);
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+
+    .history-pagination {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .history-pagination button {
+      padding: 6px 12px;
+      font-size: 12px;
+    }
+
+    .history-info {
+      font-size: 12px;
+      color: var(--color-muted);
+    }
+
     .empty-state {
       color: var(--color-empty);
       font-style: italic;
@@ -474,8 +637,86 @@
         <button id="logoutButton" class="ghost" type="button">Se déconnecter</button>
       </div>
       <div class="message" id="dashboardMessage"></div>
-      <div id="estimation" class="estimation">
-        <p class="empty-state">Aucune estimation récente.</p>
+      <div class="tabs" id="dashboardTabs">
+        <button class="tab-button active" type="button" data-tab="overview">Résumé</button>
+        <button class="tab-button" type="button" data-tab="history">Historique</button>
+      </div>
+      <div id="tabOverview" class="tab-panel">
+        <div class="summary-card">
+          <div class="summary-header">
+            <span class="summary-title">Consommation globale</span>
+            <div class="summary-controls">
+              <select id="summaryWindow" class="summary-select">
+                <option value="60">Dernière heure</option>
+                <option value="1440" selected>24 heures</option>
+                <option value="10080">7 jours</option>
+                <option value="43200">30 jours</option>
+                <option value="all">Depuis le début</option>
+                <option value="custom">Personnalisée…</option>
+              </select>
+              <div id="summaryCustomRange" class="summary-custom-range hidden">
+                <input type="datetime-local" id="summaryFrom">
+                <input type="datetime-local" id="summaryTo">
+                <button id="summaryApply" class="ghost" type="button">Appliquer</button>
+              </div>
+            </div>
+          </div>
+          <div class="history-info" id="summaryRangeInfo"></div>
+          <div class="summary-metrics">
+            <div class="summary-metric">
+              <span>Requêtes</span>
+              <strong id="summaryCount">0</strong>
+            </div>
+            <div class="summary-metric">
+              <span>Énergie totale</span>
+              <strong id="summaryTotalWh">0 Wh</strong>
+            </div>
+            <div class="summary-metric">
+              <span>Émissions</span>
+              <strong id="summaryKgCO2">0 kgCO₂</strong>
+            </div>
+            <div class="summary-metric">
+              <span>Durée cumulée</span>
+              <strong id="summaryDuration">0 s</strong>
+            </div>
+          </div>
+        </div>
+        <div id="estimation" class="estimation">
+          <p class="empty-state">Aucune estimation récente.</p>
+        </div>
+      </div>
+      <div id="tabHistory" class="tab-panel hidden">
+        <div class="history-filters">
+          <div class="field">
+            <label for="historyFrom">Du</label>
+            <input type="date" id="historyFrom">
+          </div>
+          <div class="field">
+            <label for="historyTo">Au</label>
+            <input type="date" id="historyTo">
+          </div>
+          <button id="historyApply" class="ghost" type="button">Appliquer</button>
+          <button id="historyReset" class="ghost" type="button">Réinitialiser</button>
+        </div>
+        <div class="history-table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Énergie (Wh)</th>
+                <th>Émissions (kgCO₂)</th>
+                <th>Durée (s)</th>
+              </tr>
+            </thead>
+            <tbody id="historyTableBody"></tbody>
+          </table>
+          <div id="historyEmpty" class="empty-state hidden">Aucune consommation enregistrée.</div>
+        </div>
+        <div class="history-pagination">
+          <button id="historyPrev" class="ghost" type="button">Précédent</button>
+          <span class="history-info" id="historyPageInfo"></span>
+          <button id="historyNext" class="ghost" type="button">Suivant</button>
+        </div>
       </div>
     </section>
   </main>

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -6,6 +6,7 @@ import configuration from './config/configuration';
 import { HealthController } from './health.controller';
 import { LoggingModule } from './logging/logging.module';
 import { AuthModule } from './auth/auth.module';
+import { ConsumptionModule } from './consumption/consumption.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     LoggingModule,
     AuthModule,
+    ConsumptionModule,
   ],
   controllers: [HealthController],
 })

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -13,6 +13,7 @@ export interface AuthTokensResponse {
   user: {
     id: string;
     email: string;
+    role: 'user' | 'admin';
   };
   accessToken: string;
   refreshToken: string;
@@ -80,9 +81,11 @@ export class AuthService {
   }
 
   private async generateAuthTokens(user: User): Promise<AuthTokensResponse> {
+    const role = user.role === 'admin' ? 'admin' : 'user';
     const payloadBase = {
       sub: user.id,
       email: user.email,
+      role,
     };
 
     const accessTokenTtl = this.accessTokenTtl;
@@ -110,6 +113,7 @@ export class AuthService {
       user: {
         id: user.id,
         email: user.email,
+        role,
       },
       accessToken,
       refreshToken,

--- a/server/src/auth/jwt-payload.interface.ts
+++ b/server/src/auth/jwt-payload.interface.ts
@@ -1,6 +1,7 @@
 export interface JwtPayload {
   sub: string;
   email: string;
+  role: 'user' | 'admin';
   type: 'access' | 'refresh';
   iat?: number;
   exp?: number;

--- a/server/src/consumption/consumption.controller.ts
+++ b/server/src/consumption/consumption.controller.ts
@@ -1,0 +1,141 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { JwtPayload } from '../auth/jwt-payload.interface';
+import { ConsumptionService } from './consumption.service';
+
+interface ConsumptionHistoryQuery {
+  page?: string;
+  limit?: string;
+  from?: string;
+  to?: string;
+}
+
+interface ConsumptionSummaryQuery {
+  from?: string;
+  to?: string;
+  windowMinutes?: string;
+}
+
+@UseGuards(JwtAuthGuard)
+@Controller('consumption')
+export class ConsumptionController {
+  constructor(private readonly consumptionService: ConsumptionService) {}
+
+  @Get('history')
+  async history(
+    @Req() req: Request & { user?: JwtPayload },
+    @Query() query: ConsumptionHistoryQuery,
+  ) {
+    const userId = req.user?.sub;
+    if (!userId) {
+      throw new BadRequestException('Utilisateur introuvable dans la requête');
+    }
+
+    const page = this.parsePositiveInt(query.page, 1) ?? 1;
+    const limit = this.parsePositiveInt(query.limit, 10) ?? 10;
+    const from = this.parseDate(query.from);
+    const to = this.parseDate(query.to);
+
+    if (from && to && from > to) {
+      throw new BadRequestException('La date de début doit précéder la date de fin');
+    }
+
+    const result = await this.consumptionService.getHistory(userId, {
+      page,
+      limit,
+      from,
+      to,
+    });
+
+    return {
+      ...result,
+      items: result.items.map((item) => ({
+        id: item.id,
+        occurredAt: item.occurredAt,
+        requestId: item.requestId,
+        durationSec: item.durationSec,
+        promptChars: item.promptChars,
+        replyChars: item.replyChars,
+        reqBytes: Number(item.reqBytes),
+        respBytes: Number(item.respBytes),
+        totalBytes: Number(item.totalBytes),
+        computeWh: item.computeWh,
+        networkWh: item.networkWh,
+        totalWh: item.totalWh,
+        kgCO2: item.kgCO2,
+        region: item.region,
+        kgPerKWh: item.kgPerKWh,
+      })),
+      filters: {
+        from: from?.toISOString() ?? null,
+        to: to?.toISOString() ?? null,
+      },
+    };
+  }
+
+  @Get('summary')
+  async summary(
+    @Req() req: Request & { user?: JwtPayload },
+    @Query() query: ConsumptionSummaryQuery,
+  ) {
+    const userId = req.user?.sub;
+    if (!userId) {
+      throw new BadRequestException('Utilisateur introuvable dans la requête');
+    }
+
+    const windowMinutes = this.parsePositiveInt(query.windowMinutes, undefined);
+    let from = this.parseDate(query.from);
+    const to = this.parseDate(query.to) ?? null;
+
+    if (windowMinutes && !query.from) {
+      const end = to ?? new Date();
+      from = new Date(end.getTime() - windowMinutes * 60 * 1000);
+    }
+
+    if (from && to && from > to) {
+      throw new BadRequestException('La date de début doit précéder la date de fin');
+    }
+
+    const summary = await this.consumptionService.getSummary(userId, { from, to });
+
+    return {
+      ...summary,
+      from: from?.toISOString() ?? null,
+      to: to?.toISOString() ?? null,
+    };
+  }
+
+  private parsePositiveInt(value: string | undefined, fallback: number | undefined) {
+    if (typeof value === 'undefined') {
+      return fallback;
+    }
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= 0) {
+      if (fallback === undefined) {
+        return undefined;
+      }
+      return fallback;
+    }
+    return Math.trunc(numeric);
+  }
+
+  private parseDate(value: string | undefined): Date | null {
+    if (!value) {
+      return null;
+    }
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.valueOf())) {
+      throw new BadRequestException(`Date invalide: ${value}`);
+    }
+    return parsed;
+  }
+}

--- a/server/src/consumption/consumption.module.ts
+++ b/server/src/consumption/consumption.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { ConsumptionRecord } from '../entities/consumption-record.entity';
+import { ConsumptionController } from './consumption.controller';
+import { ConsumptionService } from './consumption.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ConsumptionRecord])],
+  controllers: [ConsumptionController],
+  providers: [ConsumptionService],
+  exports: [ConsumptionService],
+})
+export class ConsumptionModule {}

--- a/server/src/consumption/consumption.service.ts
+++ b/server/src/consumption/consumption.service.ts
@@ -1,0 +1,174 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, FindOptionsWhere, MoreThanOrEqual, LessThanOrEqual, Repository } from 'typeorm';
+
+import { ConsumptionRecord } from '../entities/consumption-record.entity';
+
+export interface EstimationPayload {
+  timestamp?: string;
+  durationSec?: number;
+  promptChars?: number;
+  replyChars?: number;
+  reqBytes?: number;
+  respBytes?: number;
+  totalBytes?: number;
+  computeWh?: number;
+  networkWh?: number;
+  totalWh?: number;
+  kgCO2?: number;
+  region?: string;
+  kgPerKWh?: number;
+}
+
+export interface HistoryQueryOptions {
+  page: number;
+  limit: number;
+  from?: Date | null;
+  to?: Date | null;
+}
+
+export interface SummaryQueryOptions {
+  from?: Date | null;
+  to?: Date | null;
+}
+
+@Injectable()
+export class ConsumptionService {
+  constructor(
+    @InjectRepository(ConsumptionRecord)
+    private readonly repo: Repository<ConsumptionRecord>,
+  ) {}
+
+  async recordEstimation(userId: string, payload: EstimationPayload, requestId: string | null): Promise<void> {
+    if (!userId) {
+      return;
+    }
+
+    const occurredAt = this.resolveTimestamp(payload?.timestamp);
+    const record = this.repo.create({
+      userId,
+      occurredAt,
+      requestId,
+      durationSec: this.asNumber(payload.durationSec),
+      promptChars: this.asInteger(payload.promptChars),
+      replyChars: this.asInteger(payload.replyChars),
+      reqBytes: this.asBigIntString(payload.reqBytes),
+      respBytes: this.asBigIntString(payload.respBytes),
+      totalBytes: this.asBigIntString(payload.totalBytes),
+      computeWh: this.asNumber(payload.computeWh),
+      networkWh: this.asNumber(payload.networkWh),
+      totalWh: this.asNumber(payload.totalWh),
+      kgCO2: this.asNumber(payload.kgCO2),
+      region: typeof payload.region === 'string' && payload.region.trim() ? payload.region.trim() : 'unknown',
+      kgPerKWh: this.asNumber(payload.kgPerKWh),
+    });
+
+    await this.repo.save(record);
+  }
+
+  async getHistory(userId: string, options: HistoryQueryOptions) {
+    const page = Math.max(1, Math.trunc(options.page) || 1);
+    const limit = Math.min(50, Math.max(1, Math.trunc(options.limit) || 10));
+    const skip = (page - 1) * limit;
+
+    const where: FindOptionsWhere<ConsumptionRecord> = { userId };
+
+    if (options.from && options.to) {
+      where.occurredAt = Between(options.from, options.to);
+    } else if (options.from) {
+      where.occurredAt = MoreThanOrEqual(options.from);
+    } else if (options.to) {
+      where.occurredAt = LessThanOrEqual(options.to);
+    }
+
+    const [items, total] = await this.repo.findAndCount({
+      where,
+      order: { occurredAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.max(1, Math.ceil(total / limit) || 1),
+    };
+  }
+
+  async getSummary(userId: string, options: SummaryQueryOptions) {
+    const qb = this.repo
+      .createQueryBuilder('record')
+      .select('COUNT(*)', 'count')
+      .addSelect('COALESCE(SUM(record.totalWh), 0)', 'totalWh')
+      .addSelect('COALESCE(SUM(record.computeWh), 0)', 'totalComputeWh')
+      .addSelect('COALESCE(SUM(record.networkWh), 0)', 'totalNetworkWh')
+      .addSelect('COALESCE(SUM(record.kgCO2), 0)', 'totalKgCO2')
+      .addSelect('COALESCE(SUM(record.totalBytes), 0)', 'totalBytes')
+      .addSelect('COALESCE(SUM(record.durationSec), 0)', 'totalDurationSec')
+      .where('record.userId = :userId', { userId });
+
+    if (options.from) {
+      qb.andWhere('record.occurredAt >= :from', { from: options.from });
+    }
+
+    if (options.to) {
+      qb.andWhere('record.occurredAt <= :to', { to: options.to });
+    }
+
+    const raw = await qb.getRawOne<{
+      count: string;
+      totalWh: string;
+      totalComputeWh: string;
+      totalNetworkWh: string;
+      totalKgCO2: string;
+      totalBytes: string;
+      totalDurationSec: string;
+    }>();
+
+    return {
+      count: raw ? Number(raw.count) : 0,
+      totalWh: raw ? Number(raw.totalWh) : 0,
+      totalComputeWh: raw ? Number(raw.totalComputeWh) : 0,
+      totalNetworkWh: raw ? Number(raw.totalNetworkWh) : 0,
+      totalKgCO2: raw ? Number(raw.totalKgCO2) : 0,
+      totalBytes: raw ? Number(raw.totalBytes) : 0,
+      totalDurationSec: raw ? Number(raw.totalDurationSec) : 0,
+    };
+  }
+
+  private resolveTimestamp(timestamp?: string) {
+    if (timestamp) {
+      const parsed = new Date(timestamp);
+      if (!Number.isNaN(parsed.valueOf())) {
+        return parsed;
+      }
+    }
+    return new Date();
+  }
+
+  private asNumber(value: unknown): number {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  }
+
+  private asInteger(value: unknown): number {
+    const n = Number(value);
+    if (!Number.isFinite(n)) {
+      return 0;
+    }
+    return Math.round(n);
+  }
+
+  private asBigIntString(value: unknown): string {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+    const n = Number(value);
+    if (!Number.isFinite(n) || n < 0) {
+      return '0';
+    }
+    return Math.round(n).toString();
+  }
+}

--- a/server/src/entities/consumption-record.entity.ts
+++ b/server/src/entities/consumption-record.entity.ts
@@ -1,0 +1,71 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { User } from './user.entity';
+
+@Entity({ name: 'consumption_records' })
+export class ConsumptionRecord {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index()
+  @Column({ type: 'uuid' })
+  userId!: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @Index()
+  @Column({ type: 'timestamptz' })
+  occurredAt!: Date;
+
+  @Column({ type: 'varchar', length: 120, nullable: true })
+  requestId!: string | null;
+
+  @Column({ type: 'double precision' })
+  durationSec!: number;
+
+  @Column({ type: 'integer' })
+  promptChars!: number;
+
+  @Column({ type: 'integer' })
+  replyChars!: number;
+
+  @Column({ type: 'bigint' })
+  reqBytes!: string;
+
+  @Column({ type: 'bigint' })
+  respBytes!: string;
+
+  @Column({ type: 'bigint' })
+  totalBytes!: string;
+
+  @Column({ type: 'double precision' })
+  computeWh!: number;
+
+  @Column({ type: 'double precision' })
+  networkWh!: number;
+
+  @Column({ type: 'double precision' })
+  totalWh!: number;
+
+  @Column({ type: 'double precision' })
+  kgCO2!: number;
+
+  @Column({ type: 'varchar', length: 120 })
+  region!: string;
+
+  @Column({ type: 'double precision' })
+  kgPerKWh!: number;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -22,6 +22,9 @@ export class User {
   @Column({ type: 'varchar', length: 512, nullable: true })
   refreshTokenHash!: string | null;
 
+  @Column({ type: 'varchar', length: 30, default: 'user' })
+  role!: 'user' | 'admin';
+
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt!: Date;
 

--- a/server/src/logging/logging.controller.ts
+++ b/server/src/logging/logging.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { Request } from 'express';
 
 import { CreateLogEventDto } from './dto/create-log-event.dto';
 import { LoggingService } from './logging.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { JwtPayload } from '../auth/jwt-payload.interface';
 
 @Controller('events')
 export class LoggingController {
@@ -10,8 +12,11 @@ export class LoggingController {
 
   @UseGuards(JwtAuthGuard)
   @Post()
-  async create(@Body() dto: CreateLogEventDto) {
-    const created = await this.loggingService.create(dto);
+  async create(
+    @Body() dto: CreateLogEventDto,
+    @Req() req: Request & { user?: JwtPayload },
+  ) {
+    const created = await this.loggingService.create(dto, req.user ?? null);
     return { id: created.id, createdAt: created.createdAt };
   }
 

--- a/server/src/logging/logging.module.ts
+++ b/server/src/logging/logging.module.ts
@@ -5,9 +5,10 @@ import { LogEvent } from '../entities/log-event.entity';
 import { AuthModule } from '../auth/auth.module';
 import { LoggingController } from './logging.controller';
 import { LoggingService } from './logging.service';
+import { ConsumptionModule } from '../consumption/consumption.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([LogEvent]), AuthModule],
+  imports: [TypeOrmModule.forFeature([LogEvent]), AuthModule, ConsumptionModule],
   controllers: [LoggingController],
   providers: [LoggingService],
   exports: [LoggingService],

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -16,6 +16,7 @@ export class UsersService {
       email,
       passwordHash,
       refreshTokenHash: null,
+      role: 'user',
     });
     return this.usersRepository.save(user);
   }


### PR DESCRIPTION
## Summary
- add a consumption record entity and module that persists per-user estimation events when logs are created
- expose authenticated history and summary endpoints with pagination, date filters, and optional rolling windows
- refresh the popup dashboard with tabbed consumption views, live totals, and JWT roles for future access control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de3c7f2324832cac315ecff29f2ab9