### PR TITLE
Refine overview tab layout and add summary range presets

### DIFF
--- a/front/popup/popup.html
+++ b/front/popup/popup.html
@@ -59,7 +59,8 @@
 
     body {
       margin: 0;
-      min-width: 320px;
+      min-width: 300px;
+      width: min(340px, 100vw);
       background: var(--color-bg);
       color: var(--color-text);
       font: 13px/1.45 "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -379,15 +380,21 @@
 
     .top-row {
       display: flex;
-      justify-content: space-between;
+      flex-wrap: wrap;
       align-items: flex-start;
       gap: 12px;
+    }
+
+    .top-row .logout-button {
+      align-self: flex-start;
     }
 
     .user-block {
       display: flex;
       flex-direction: column;
       gap: 2px;
+      margin-left: auto;
+      text-align: right;
     }
 
     .user-label {
@@ -463,6 +470,8 @@
       color: var(--color-muted);
       cursor: pointer;
       transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+      flex: 1 1 0;
+      text-align: center;
     }
 
     .tab-button:hover {
@@ -536,6 +545,56 @@
     .filters-actions {
       display: flex;
       gap: 8px;
+    }
+
+    .summary-filters {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .summary-range-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .summary-range-buttons .range-button {
+      flex: 1 1 120px;
+      min-width: 120px;
+      background: transparent;
+      border-radius: 999px;
+      border: 1px solid var(--color-border);
+      padding: 7px 12px;
+      font-weight: 600;
+      font-size: 12px;
+      color: var(--color-muted);
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    }
+
+    .summary-range-buttons .range-button:hover {
+      color: var(--color-text);
+      border-color: rgba(99, 102, 241, 0.35);
+      background: rgba(99, 102, 241, 0.1);
+    }
+
+    .summary-range-buttons .range-button.active {
+      color: var(--color-text);
+      border-color: rgba(99, 102, 241, 0.55);
+      background: rgba(99, 102, 241, 0.18);
+    }
+
+    .summary-custom-range {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: flex-end;
+    }
+
+    .summary-custom-range .field {
+      flex: 1 1 150px;
+      min-width: 140px;
     }
 
     .metrics-grid {
@@ -678,12 +737,12 @@
 
     <section id="dashboardSection" class="card hidden">
       <div class="top-row">
+        <button id="logoutButton" class="ghost logout-button" type="button">Se déconnecter</button>
         <div class="user-block">
           <span class="user-label">Connecté</span>
           <span class="user-email" id="currentUserEmail"></span>
           <span class="user-role" id="currentUserRole"></span>
         </div>
-        <button id="logoutButton" class="ghost" type="button">Se déconnecter</button>
       </div>
       <div class="message" id="dashboardMessage"></div>
       <div class="tab-container">
@@ -697,18 +756,26 @@
               <h2>Consommation globale</h2>
               <span class="summary-updated" id="summaryUpdated"></span>
             </div>
-            <form id="summaryFilters" class="filters-row">
-              <div class="field">
-                <label for="summaryFrom">De</label>
-                <input type="datetime-local" id="summaryFrom" name="from">
+            <form id="summaryFilters" class="summary-filters">
+              <div class="summary-range-buttons" role="group" aria-label="Plages rapides">
+                <button type="button" class="range-button" data-summary-range="today">Aujourd'hui</button>
+                <button type="button" class="range-button" data-summary-range="7d">7 jours</button>
+                <button type="button" class="range-button" data-summary-range="1m">1 mois</button>
+                <button type="button" class="range-button" data-summary-range="custom">Personnaliser</button>
               </div>
-              <div class="field">
-                <label for="summaryTo">À</label>
-                <input type="datetime-local" id="summaryTo" name="to">
-              </div>
-              <div class="filters-actions">
-                <button type="submit" class="ghost">Mettre à jour</button>
-                <button type="button" class="ghost" id="summaryReset">Réinitialiser</button>
+              <div class="summary-custom-range hidden" id="summaryCustomRange">
+                <div class="field">
+                  <label for="summaryFrom">De</label>
+                  <input type="datetime-local" id="summaryFrom" name="from">
+                </div>
+                <div class="field">
+                  <label for="summaryTo">À</label>
+                  <input type="datetime-local" id="summaryTo" name="to">
+                </div>
+                <div class="filters-actions">
+                  <button type="submit" class="ghost">Mettre à jour</button>
+                  <button type="button" class="ghost" id="summaryReset">Réinitialiser</button>
+                </div>
               </div>
             </form>
             <div class="metrics-grid" id="summaryMetrics">


### PR DESCRIPTION
## Summary
- shrink the popup width and adjust the dashboard header so the logout button anchors to the left
- give overview/history tabs consistent sizing and add preset range buttons plus a custom date section in the overview filters
- update popup script to manage summary presets, toggle the custom range UI, and keep realtime updates in sync with the selected window

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e049a1f988832cb5b556110587acbf